### PR TITLE
basic enhancement

### DIFF
--- a/RailsOneClick/AppController.h
+++ b/RailsOneClick/AppController.h
@@ -15,4 +15,6 @@
 
 - (void)rubyInstalled;
 
+- (BOOL)isRubyInstalled;
+
 @end

--- a/RailsOneClick/AppController.m
+++ b/RailsOneClick/AppController.m
@@ -15,11 +15,21 @@
 @synthesize view;
 @synthesize currentViewController;
 
-- (BOOL)isRailsInstalled
+- (BOOL)isFileExists:(NSString *)path
 {
     NSString* documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString* foofile = [documentsPath stringByAppendingPathComponent:@"rails_one_click/ruby/bin/rails"];
+    NSString* foofile = [documentsPath stringByAppendingPathComponent:path];
     return [[NSFileManager defaultManager] fileExistsAtPath:foofile];
+}
+
+- (BOOL)isRubyInstalled
+{
+    return [self isFileExists:@"rails_one_click/ruby/bin/ruby"];
+}
+
+- (BOOL)isRailsInstalled
+{
+    return [self isFileExists:@"rails_one_click/ruby/bin/rails"];
 }
 
 - (void)awakeFromNib

--- a/RailsOneClick/Settings.h
+++ b/RailsOneClick/Settings.h
@@ -1,6 +1,10 @@
 
 #define INSTALLATION_ERROR_MESSAGE @"There was an error during the installation. Please open an issue at https://github.com/oscardelben/RailsOneClick with the content of the log window."
 
+#define INSTALLATION_MESSAGE_RUBY_FAILED @"There was an error while installing ruby. Please open an issue at https://github.com/oscardelben/RailsOneClick with the content of the log window."
+
+#define INSTALLATION_MESSAGE_RAILS_FAILED @"There was an error while installing rails. Please open an issue at https://github.com/oscardelben/RailsOneClick with the content of the log window."
+
 #define INSTALLATION_SUCCESS_MESSAGE @"Ruby on Rails was correctly installed in your system!"
 
 #define PREREQUISITES_INSTALLATION_MESSAGE @"Before developing on Mac os X you need to download a free copy of the \"Command Line Tools for Xcode\" package from https://developer.apple.com/downloads"


### PR DESCRIPTION
added 3 basic enhancements:
1. Inform user when the installation is failed while installing ruby or rails. Currently, the program will tell the user that installation is successful even when it actually failed.
2. Disable the checkPrerequisitesButton during the installation process. It seems weird to me that I can check the prerequisites when I'm actually installing.
3. Skip ruby installation process when it is already installed.
